### PR TITLE
misc/hicolor-icon-theme

### DIFF
--- a/misc/hicolor-icon-theme/Makefile
+++ b/misc/hicolor-icon-theme/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	hicolor-icon-theme
 PORTVERSION=	0.15
+PORTREVISION= 1
 CATEGORIES=	misc gnome
 MASTER_SITES=	http://icon-theme.freedesktop.org/releases/
 

--- a/misc/hicolor-icon-theme/pkg-install
+++ b/misc/hicolor-icon-theme/pkg-install
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Script to tie the older pixmaps directory into the newer XDG icon theme spec
+
+PREFIX=${PKG_PREFIX-/usr/local}
+
+if [ "$2" != "POST-INSTALL" ] ; then
+   exit 0
+fi
+
+set +e
+
+# If this is during staging, we can skip for now
+echo $PREFIX | grep -q '/stage/'
+if [ $? -eq 0 ] ; then
+   exit 0
+fi
+
+# Link the older "pixmaps" dir into the hicolor icon theme dir
+ln -s ${PREFIX}/share/pixmaps ${PREFIX}/share/icons/hicolor/pixmaps
+
+# Now add an entry for the pixmaps dir into the hicolor index.theme
+echo "
+[pixmaps]
+MinSize=8
+Size=16
+MaxSize=512
+Context=Applications
+Type=Scalable" >> ${PREFIX}/share/icons/hicolor/index.theme
+
+#And ensure that the pixmaps dir is listed at the end of the "Directories=" line/list
+sed -i theme '/^Directories=/s/$/,pixmaps/ ' ${PREFIX}/share/icons/hicolor/index.theme
+
+exit 0


### PR DESCRIPTION
Add support for the legacy "pixmaps" directory directly into the hicolor icon theme.
This allows XDG icon searches through the theme specifications to find the icons for applications like firefox and thunderbird (which still put their icons into the older pixmaps dir and not into the hicolor theme directly).