### PR TITLE
Update openrc-powerd++.in

### DIFF
--- a/sysutils/powerdxx/Makefile
+++ b/sysutils/powerdxx/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	powerdxx
 DISTVERSION=	0.3.0
+PORTREVISION=	1
 CATEGORIES=	sysutils
 
 MAINTAINER=	lebarondemerde@privacychain.ch

--- a/sysutils/powerdxx/files/openrc-powerd++.in
+++ b/sysutils/powerdxx/files/openrc-powerd++.in
@@ -11,14 +11,16 @@ depend()
 	use logger
 	after bootmisc
 	keyword -jail -prefix
+	provide powerd
 }
 
 start_pre()
 {
-	if [ -n "$powerd++_battery_mode" ]; then
+	#Need to be careful not to overwrite the same flags passed in via powerd_args
+	if [ -n "$powerd_battery_mode" ] && [ 0 -ne `echo "${command_args}" | grep -q -E ".* -b .*"` ] ; then
 		command_args="$command_args -b $powerd_battery_mode"
 	fi
-	if [ -n "${powerd++_ac_mode}" ]; then
+	if [ -n "${powerd_ac_mode}" ] && [ 0 -ne `echo "${command_args}" | grep -q -E ".* -a .*"` ] ; then
 		command_args="$command_args -a $powerd_ac_mode"
 	fi
 }


### PR DESCRIPTION
* Fix an inconsistency in the check/usage of powerd_* rc.conf settings.
* Make this service "provide" powerd (so that it will conflict with the powerd service as needed - only one can run at any time)
* Add verification of the input arguments. Make sure the powerd_[ac/battery]_mode variables are ignored if those same flags are already set manually via power_args.