### PR TITLE
Update www/falkon:

### DIFF
--- a/www/falkon/Makefile
+++ b/www/falkon/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	falkon
 DISTVERSION=	3.0.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	www
 MASTER_SITES=	KDE/stable/falkon/${DISTVERSION:R}/src/
 
@@ -13,7 +13,7 @@ LICENSE=	GPLv3
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		cmake:outsource desktop-file-utils kde:5 qt:5 ssl tar:xz
-USE_KDE=	wallet
+USE_KDE=	wallet_build
 USE_QT=		core dbus gui location network printsupport qml quick \
 		sql webchannel webengine widgets x11extras \
 		buildtools_build qmake_build


### PR DESCRIPTION
Add the "_build" tag to the KDE5 wallet dependency.
During the build, Falkon can compile-in optional support for the KF5 wallet if the KF5 wallet is installed at built-time. Once that is finished though, the KF5 wallet integration becomes an *optional* runtime plugin - so the KF5 utilities and libraries should not be forced as runtime dependencies in the FreeBSD port.