### PR TITLE
Fix devel/qt5-core post-install routine

### DIFF
--- a/devel/qt5-core/Makefile
+++ b/devel/qt5-core/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	core
 DISTVERSION=	${QT5_VERSION}
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	devel
 PKGNAMEPREFIX=	qt5-
 
@@ -51,9 +51,6 @@ pre-build:
 .endfor
 
 post-install:
-# Allow qconfig.h to be customized by single ports.
-	${AWK} 'BEGIN{print "#include <QtCore/qconfig-modules.h>"}{print}' \
-		${STAGEDIR}${PREFIX}/${QT_INCDIR_REL}/QtCore/qconfig.h > ${WRKDIR}/qconfig.h
 # Cleanup qconfig.h and remove stray '#define QT_NO_FOO'
 	${REINPLACE_CMD} "/#define QT_NO_/d" ${WRKDIR}/qconfig.h
 	${MV} ${WRKDIR}/qconfig.h ${STAGEDIR}${PREFIX}/${QT_INCDIR_REL}/QtCore/qconfig.h


### PR DESCRIPTION
Remove the insertion of an include line to ${STAGEDIR}${PREFIX}/${QT_INCDIR_REL}/QtCore/qconfig.h which adds a dependency on a non-existant qconfig-modules.h file. 
That insertion completely breaks the ability to build Qt5 utilities *outside* of the FreeBSD ports system since that qconfig-modules.h file does not exist in the qt5-core port/package.