### PR TITLE
Add a new OpenRC service for net/openmdns

### DIFF
--- a/net/openmdns/Makefile
+++ b/net/openmdns/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	openmdns
 DISTVERSION=	0.7
+PORTREVISION=	1
 CATEGORIES=	net
 
 MAINTAINER=	jbeich@FreeBSD.org

--- a/net/openmdns/Makefile.trueos
+++ b/net/openmdns/Makefile.trueos
@@ -1,0 +1,1 @@
+USE_OPENRC_SUBR=	openrc-mdnsd

--- a/net/openmdns/files/openrc-mdnsd.in
+++ b/net/openmdns/files/openrc-mdnsd.in
@@ -1,0 +1,48 @@
+#!/sbin/openrc-run
+
+# mdnsd_flags (string):	Arguments passed to mdnsd(8) such as the list of
+#			network interfaces to listen on e.g., "em0 fxp0".
+#			Default: Will automatically use all network interfaces (excluding lo*)
+
+#============
+# Notes about OpenRC version of service
+#====== (Ken Moore ken@ixsystems.com : 9/13/2018 ) =====
+# mdnsd does not create/use a pidfile when it does into "daemon" mode, rendering it
+#   nearly impossible for OpenRC to manage the process once it is started.
+# To get around this, we need to force it into the foreground with the "-d" flag and have 
+#   OpenRC itself background the process (with a pidfile) so that status and start/stop 
+#   behave as expected. This forces the use of the [output/error]_log entries as well, otherwise
+#   the service will spam the console with tons of messages (-d puts it in verbose mode too).
+# ============
+
+name="mdnsd"
+description="Multicast DNS and Service Discovery daemon"
+command="%%PREFIX%%/sbin/${name}"
+pidfile="/var/run/${name}.pid"
+supervisor="supervise-daemon"
+output_log="/var/log/${name}.log"
+error_log=${output_log}
+
+depend() {
+	use net
+	provide mdns
+	keyword -shutdown
+}
+
+start_pre(){
+  if [ -z "${mdnsd_flags}" ] ; then
+    #Automatic device setup
+    # Get the list of all network devices (except loopback devices)
+    for dev in `ifconfig -l`
+    do
+      echo "${dev}" | grep -qE "lo[0-9]"
+      if [ $? -ne 0 ] ; then
+        mdnsd_flags="${mdnsd_flags} ${dev}"
+      fi
+    done
+  fi
+  #In order for OpenRC to be able to probe status of service,
+  # it needs to be run in the foreground and have OpenRC provide the backgrounding
+  command_args="-d ${mdnsd_flags}"
+}
+


### PR DESCRIPTION
This service will automatically use any network interfaces that are available on the system unless otherwise specified with the "mdnsd_flags=" option in rc.conf.