### PR TITLE
Fix up the www/falkon port.

### DIFF
--- a/www/falkon/Makefile
+++ b/www/falkon/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	falkon
 DISTVERSION=	3.0.0
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	www
 MASTER_SITES=	KDE/stable/falkon/${DISTVERSION:R}/src/
 
@@ -14,7 +14,7 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		cmake:outsource desktop-file-utils qt:5 ssl tar:xz kde:5
 USE_QT=		core dbus gui location network printsupport qml quick \
-		sql webchannel webengine widgets x11extras \
+		sql webchannel webengine widgets x11extras linguist_build \
 		buildtools_build qmake_build
 USE_KDE=	ecm_build
 USE_XORG=	xcb

--- a/www/falkon/pkg-plist
+++ b/www/falkon/pkg-plist
@@ -6,7 +6,7 @@ lib/libFalkonPrivate.so.3.0.0
 %%GNOMEKEYRING%%%%QT_PLUGINDIR%%/falkon/GnomeKeyringPasswords.so
 %%QT_PLUGINDIR%%/falkon/GreaseMonkey.so
 %%QT_PLUGINDIR%%/falkon/ImageFinder.so
-%%QT_PLUGINDIR%%/falkon/KWalletPasswords.so
+%%KWALLET%%%%QT_PLUGINDIR%%/falkon/KWalletPasswords.so
 %%QT_PLUGINDIR%%/falkon/MouseGestures.so
 %%QT_PLUGINDIR%%/falkon/PIM.so
 %%QT_PLUGINDIR%%/falkon/StatusBarIcons.so


### PR DESCRIPTION
Ensure that all dependencies are properly listed now, and update the plist to account to the files needed by the different build options.

This has been tested/verified with the Project Trident builds.