### PR TITLE
Add a new strip-plist.sh to Mk/Scripts which handles user specified

### DIFF
--- a/Mk/Scripts/strip-plist.sh
+++ b/Mk/Scripts/strip-plist.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+PLIST="$1"
+
+if [ ! -e "/etc/strip-plist-ports" ] ; then
+	echo "ERROR: Missing /etc/strip-plist-ports" >&2
+	exit 1
+fi
+
+# If the user has specified a list of files / expressions to strip from
+# a ports plist, lets handle that now
+while read strip
+do
+	grep -q " $strip" ${PLIST}
+	if [ $? -ne 0 ] ; then continue ; fi
+
+	cat ${PLIST} | grep -v " $strip" > ${PLIST}.new
+	mv ${PLIST}.new ${PLIST}
+done < /etc/strip-plist-ports
+

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -3415,6 +3415,10 @@ ${PKGLATESTFILE}: ${PKGFILE} ${PKGLATESTREPOSITORY}
 
 # from here this will become a loop for subpackages
 ${WRKDIR_PKGFILE}: ${TMPPLIST} create-manifest ${WRKDIR}/pkg
+# Check if we have packages to "strip" plist items from
+	@if [ -e "/etc/strip-plist-ports" ] ; then \
+			${SCRIPTSDIR}/strip-plist.sh ${TMPPLIST} ; \
+	fi
 	@if ! ${SETENV} ${PKG_ENV} FORCE_POST="${_FORCE_POST_PATTERNS}" ${PKG_CREATE} ${PKG_CREATE_ARGS} -m ${METADIR} -p ${TMPPLIST} -f ${PKG_SUFX:S/.//} -o ${WRKDIR}/pkg ${PKGNAME}; then \
 		cd ${.CURDIR} && eval ${MAKE} delete-package >/dev/null; \
 		exit 1; \


### PR DESCRIPTION
items they want to "strip" out of package creation without having to
go modify each and every port.

This will be used for TRUEOS_MANIFEST to allow things like FreeNAS
to dynamically remove things from the resulting packages that are
making images too large