### PR TITLE
Update Makefile.inc

### DIFF
--- a/emulators/i386-wine/Makefile.inc
+++ b/emulators/i386-wine/Makefile.inc
@@ -57,8 +57,8 @@ PLIST_SUB+=	OSREL${osrel}="@comment "
 .endif
 .endfor
 
-.if ${OPSYS} != FreeBSD || (!(${OSVERSION} < 1000000) && !(${OSVERSION} >= 1003000 && ${OSVERSION} < 1100000) && !(${OSVERSION} >= 1101000 && ${OSVERSION} < 1200000) && !(${OSVERSION} >= 1200056 && ${OSVERSION} < 1300000))
-IGNORE=		binaries compiled for FreeBSD 10.3+, 11.0+ and -current only
+.if ${OPSYS} != FreeBSD || (!(${OSVERSION} < 1000000) && !(${OSVERSION} >= 1003000 && ${OSVERSION} < 1100000) && !(${OSVERSION} >= 1101000 && ${OSVERSION} < 1200000) && !(${OSVERSION} >= 1200056 && ${OSVERSION} < 1400000))
+IGNORE=		binaries compiled for FreeBSD 10.3+, 11.0+, 12.0+, and -current only
 DISTFILES=
 .endif
 


### PR DESCRIPTION
Allow i386-wine to build on FreeBSD 13.0 (Current)
Not sure why all this version checking is important since the end result is any version > 10.3-release, but that could be a PR for later...