### PR TITLE
Fix for QNetworkInterface undefined symbol error when starting up Qt5 networking apps (e.g. falkon, telegram)

### DIFF
--- a/net/qt5-network/files/patch-src_plugins_bearer_generic__qgenericengine.cpp
+++ b/net/qt5-network/files/patch-src_plugins_bearer_generic__qgenericengine.cpp
@@ -1,0 +1,16 @@
+--- src/plugins/bearer/generic/qgenericengine.cpp.orig	2018-09-13 00:25:10.000000000 -0400
++++ src/plugins/bearer/generic/qgenericengine.cpp	2018-11-26 03:28:10.640751000 -0500
+@@ -231,9 +231,13 @@
+ QGenericEngine::QGenericEngine(QObject *parent)
+ :   QBearerEngineImpl(parent)
+ {
++
++#ifndef QT_NO_NETWORKINTERFACE
+     //workaround for deadlock in __cxa_guard_acquire with webkit on macos x
+     //initialise the Q_GLOBAL_STATIC in same thread as the AtomicallyInitializedStatic
+     (void)QNetworkInterface::interfaceFromIndex(0);
++#endif
++
+ }
+ 
+ QGenericEngine::~QGenericEngine()


### PR DESCRIPTION
When starting up Qt5 apps this plugin causes obscure undefined QNetworkInterface symbol error. 
Disabling this code causes the issue to disappear. This started to happen after upgrade to Qt5.11.2. 
This needs to be investigated further with regards to any changes in  dynamic linker environment (e.g. Trident build).

After applying this patch the Qt5 networking apps started up succesfully without linkage issues.