### PR TITLE
Update openrc-powerd++.in

### DIFF
--- a/sysutils/powerdxx/files/openrc-powerd++.in
+++ b/sysutils/powerdxx/files/openrc-powerd++.in
@@ -11,7 +11,6 @@ depend()
 	use logger
 	after bootmisc
 	keyword -jail -prefix
-	provide powerd
 }
 
 start_pre()


### PR DESCRIPTION
Remove the "provide powerd" line from powerd++ service. This just causes warnings because powerd is already a "real" service name.