### PR TITLE
Fix linking against LIBGL.so with nvidia-driver

### DIFF
--- a/x11/nvidia-driver/Makefile
+++ b/x11/nvidia-driver/Makefile
@@ -12,7 +12,7 @@
 PORTNAME=	nvidia-driver
 DISTVERSION?=	390.87
 # Always try to set PORTREVISION as it can be overridden by the slave ports
-PORTREVISION?=	0
+PORTREVISION?=	1
 CATEGORIES=	x11
 MASTER_SITES=	NVIDIA/XFree86/FreeBSD-${ARCH_SUFX}/${DISTVERSION}
 DISTNAME=	NVIDIA-FreeBSD-${ARCH_SUFX}-${DISTVERSION}
@@ -237,20 +237,24 @@ post-install: .SILENT
 	${REINPLACE_CMD} -E '/\/lib\/libGLESv[12](_CM)?(\.so)?(_nvidia.so(\.[0-9]|\.[0-9]+\.[0-9]+)?)?$$/d ; \
 		/libEGL_nvidia\.so\.${PORTVERSION}/d' ${TMPPLIST}
 .endif
-# rename libGL.so, libEGL.so and libGLESv2.so
-	${MV} -f ${STAGEDIR}${PREFIX}/lib/libGL.so \
+# Link NVIDIA libraries to point to correct files.
+# libGL.so, libEGL.so and libGLESv2.so should not be provided by this port.
+	${LN} -sf libGL-NVIDIA.so.1 \
 		${STAGEDIR}${PREFIX}/lib/libGL-NVIDIA.so
 	${MV} -f ${STAGEDIR}${PREFIX}/lib/libGL.so.1 \
 		${STAGEDIR}${PREFIX}/lib/libGL-NVIDIA.so.1
+	${RM} -f ${STAGEDIR}${PREFIX}/lib/libGL.so
 .if ${NVVERSION} >= 331.013
-	${MV} -f ${STAGEDIR}${PREFIX}/lib/libEGL.so \
+	${LN} -sf libEGL-NVIDIA.so.1 \
 		${STAGEDIR}${PREFIX}/lib/libEGL-NVIDIA.so
 	${MV} -f ${STAGEDIR}${PREFIX}/lib/libEGL.so.1 \
 		${STAGEDIR}${PREFIX}/lib/libEGL-NVIDIA.so.1
-	${MV} -f ${STAGEDIR}${PREFIX}/lib/libGLESv2.so \
+	${RM} -f ${STAGEDIR}${PREFIX}/lib/libEGL.so
+	${LN} -sf libGLESv2-NVIDIA.so.2 \
 		${STAGEDIR}${PREFIX}/lib/libGLESv2-NVIDIA.so
 	${MV} -f ${STAGEDIR}${PREFIX}/lib/libGLESv2.so.2 \
 		${STAGEDIR}${PREFIX}/lib/libGLESv2-NVIDIA.so.2
+	${RM} -f ${STAGEDIR}${PREFIX}/lib/libGLESv2.so
 .endif
 	@${MKDIR} ${STAGEDIR}${PREFIX}/etc/libmap.d/
 	${INSTALL_DATA} ${WRKDIR}/nvidia.conf \


### PR DESCRIPTION
This addresses FreeBSD bugzilla ticket 226403
This is to address not being able to link against libGL.so with nvidia-driver.
This fixes GDM, LightDM, and possibly many more applications.
As of the time of this commit FreeBSD still has not pulled in this fix.

@miwi-fbsd Please confirm you are ok with how I did this, and set the port revision.  I am applying this fix to stable-18.12 only as port in master is already at revision 1 and broken.  Not only does the patch not apply cleanly but I cannot get it to build after it seemed to be affected by a major rework of many ports to  "Install both 32 bit and 64 bit Linux libraries from the official Linux".