### PR TITLE
Fix www/chromium runtime linkage error due to environ symbol being undefined

### DIFF
--- a/www/chromium/files/patch-build_linux_chrome.map
+++ b/www/chromium/files/patch-build_linux_chrome.map
@@ -1,0 +1,11 @@
+--- build/linux/chrome.map	2018-08-08 15:10:32.000000000 -0400
++++ build/linux/chrome.map	2019-01-06 11:24:39.667365000 -0500
+@@ -82,6 +82,8 @@
+   localtime64_r;
+   localtime_r;
+ 
++  __progname;
++  environ;	
+ local:
+   *;
+ };


### PR DESCRIPTION
While it is still being discussed at FreeBSD upstream where the ultimate fix should be implemented here is the patch to linker version script discussed and tested on bugtracker: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=220103

www/chromium started up successfully. So perhaps TrueOS does not need to wait on FreeBSD upstream while the discussion is still going...