### PR TITLE
Fix multimedia/mplayer runtime linkage error due to environ symbol being undefined

### DIFF
--- a/multimedia/mplayer/files/patch-binary.ver
+++ b/multimedia/mplayer/files/patch-binary.ver
@@ -1,0 +1,14 @@
+--- binary.ver	2019-01-05 17:27:14.744317000 -0500
++++ binary.ver	2019-01-05 17:27:43.727355000 -0500
+@@ -1,5 +1,9 @@
+ MPLAYER_1 {
+-  # to support glibcs abhorrent backwards-compatibility hack
+-  global: _IO_stdin_used;
+   local: *;
++  # to support glibcs abhorrent backwards-compatibility hack
++  global: 
++	_IO_stdin_used;
++	#FreeBSD specific variables
++	__progname;
++	environ;
+ };


### PR DESCRIPTION
While it is still being discussed at FreeBSD upstream where the ultimate fix should be implemented here is the patch to linker version script discussed and tested on bugtracker: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=220103

www/chromium started up successfully. So perhaps TrueOS does not need to wait on FreeBSD upstream while the discussion is still going...