### PR TITLE
Fix www/iridium runtime linkage error due to environ being undefined

### DIFF
--- a/www/iridium/files/patch-build_linux_chrome.map
+++ b/www/iridium/files/patch-build_linux_chrome.map
@@ -1,0 +1,12 @@
+--- build/linux/chrome.map.orig	2018-05-09 15:05:34.000000000 -0400
++++ build/linux/chrome.map	2019-01-06 16:50:04.993256000 -0500
+@@ -82,6 +82,9 @@
+   localtime64_r;
+   localtime_r;
+ 
++  #FreeBSD specific variables
++  __progname;
++  environ; 	
+ local:
+   *;
+ };


### PR DESCRIPTION
While it is still being discussed at FreeBSD upstream where the ultimate fix should be implemented here is the patch to linker version script discussed and tested on bugtracker: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=220103

www/chromium started up successfully. So perhaps TrueOS does not need to wait on FreeBSD upstream while the discussion is still going...
