### PR TITLE
[change] New Port: os/manifest

### DIFF
--- a/os/Makefile
+++ b/os/Makefile
@@ -7,6 +7,7 @@
     SUBDIR += buildworld
     SUBDIR += kernel
     SUBDIR += kernel-debug
+    SUBDIR += manifest
     SUBDIR += src
     SUBDIR += userland
     SUBDIR += userland-base

--- a/os/manifest/Makefile
+++ b/os/manifest/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	manifest
-PORTVERSION=	${:!stat -f %Sm -t %s ${PORTSDIR}/trueos-manifest.json!}
+PORTVERSION=	${:!/usr/bin/stat -f %Sm -t %s ${PORTSDIR}/trueos-manifest.json!}
 CATEGORIES=	os
 
 MAINTAINER=	ken@ixsystems.com

--- a/os/manifest/Makefile
+++ b/os/manifest/Makefile
@@ -12,7 +12,6 @@ NO_BUILD=	yes
 EXTRACT_ONLY=
 DISTFILES=
 PLIST_FILES=	/var/db/current-manifest.json
-PLIST_DIRS=		/var/db
 
 .include <bsd.port.pre.mk>
 

--- a/os/manifest/Makefile
+++ b/os/manifest/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	manifest
-PORTVERSION=	${:!/usr/bin/stat -f %Sm -t %s ${PORTSDIR}/trueos-manifest.json!}
+PORTVERSION=	${:!/usr/bin/stat -f %Sm -t %s ${PORTSDIR}/local_source/trueos-manifest.json!}
 CATEGORIES=	os
 
 MAINTAINER=	ken@ixsystems.com
@@ -17,6 +17,6 @@ PLIST_FILES=	/var/db/current-manifest.json
 
 do-install:
 	@${MKDIR} -p ${STAGEDIR}/var/db
-	@${CP} ${PORTSDIR}/trueos-manifest.json ${STAGEDIR}/var/db/current-manifest.json
+	@${CP} ${PORTSDIR}/local_source/trueos-manifest.json ${STAGEDIR}/var/db/current-manifest.json
 
 .include <bsd.port.post.mk>

--- a/os/manifest/Makefile
+++ b/os/manifest/Makefile
@@ -1,0 +1,23 @@
+# $FreeBSD$
+
+PORTNAME=	manifest
+PORTVERSION=	${:!stat -f %Sm -t %s ${PORTSDIR}/trueos-manifest.json!}
+CATEGORIES=	os
+
+MAINTAINER=	ken@ixsystems.com
+COMMENT=	Port for the latest package build manifest
+
+PREFIX=/
+NO_BUILD=	yes
+EXTRACT_ONLY=
+DISTFILES=
+PLIST_FILES=	/var/db/current-manifest.json
+PLIST_DIRS=		/var/db
+
+.include <bsd.port.pre.mk>
+
+do-install:
+	@${MKDIR} -p ${STAGEDIR}/var/db
+	@${CP} ${PORTSDIR}/trueos-manifest.json ${STAGEDIR}/var/db/current-manifest.json
+
+.include <bsd.port.post.mk>

--- a/os/manifest/pkg-descr
+++ b/os/manifest/pkg-descr
@@ -1,0 +1,4 @@
+Build manifest for the current version of the packages.
+Gets installed to /var/db/current-manifest.json
+
+WWW: https://github.com/trueos/trueos


### PR DESCRIPTION
This is a simple port which has one file: /var/db/current-manifest.json
This is just a copy of the TRUEOS_MANIFEST file used to do the builds, so that build manifest can be used for all sorts of things like version control, build-tagging, port build references, and more.