### PR TITLE
Quick fix for the microcode updates OpenRC service (sysutils/devcpu-d…

### DIFF
--- a/sysutils/devcpu-data/files/openrc-microcode_update.in
+++ b/sysutils/devcpu-data/files/openrc-microcode_update.in
@@ -39,6 +39,11 @@ start() {
 	einfo "Done."
 }
 
+stop(){
+  #This is just a one-shot service without any daemon - nothing to stop.
+  return 0
+}
+
 depend() {
 	need localmount
 	keyword -jail


### PR DESCRIPTION
…ata)

This does not run as a daemon - silence the "stop" routine by instantly returning 0